### PR TITLE
Fix incomplete current-user profile data

### DIFF
--- a/Identity.Base.Tests/IdentityDisplayNameResolverTests.cs
+++ b/Identity.Base.Tests/IdentityDisplayNameResolverTests.cs
@@ -1,0 +1,40 @@
+using Identity.Base.Identity;
+using Identity.Base.Options;
+using Shouldly;
+
+namespace Identity.Base.Tests;
+
+public class IdentityDisplayNameResolverTests
+{
+    [Fact]
+    public void Resolve_UsesConfiguredFullName()
+    {
+        var metadata = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["fullName"] = "  Full Name User  "
+        };
+        var fields = new[]
+        {
+            new RegistrationProfileFieldOptions { Name = "fullName", DisplayName = "Full name" }
+        };
+
+        IdentityDisplayNameResolver.Resolve(metadata, fields).ShouldBe("Full Name User");
+    }
+
+    [Fact]
+    public void Resolve_PrefersDisplayName_WhenBothAliasesAreConfigured()
+    {
+        var metadata = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["displayName"] = "Preferred Name",
+            ["fullName"] = "Full Name"
+        };
+        var fields = new[]
+        {
+            new RegistrationProfileFieldOptions { Name = "fullName", DisplayName = "Full name" },
+            new RegistrationProfileFieldOptions { Name = "displayName", DisplayName = "Display name" }
+        };
+
+        IdentityDisplayNameResolver.Resolve(metadata, fields).ShouldBe("Preferred Name");
+    }
+}

--- a/Identity.Base.Tests/RegistrationEndpointTests.cs
+++ b/Identity.Base.Tests/RegistrationEndpointTests.cs
@@ -3,6 +3,8 @@ using System.Net.Http.Json;
 using Shouldly;
 using Identity.Base.Data;
 using Identity.Base.Features.Email;
+using Identity.Base.Options;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -52,10 +54,53 @@ public class RegistrationEndpointTests : IClassFixture<IdentityApiFactory>
         createdUser.ProfileMetadata.Values.ShouldContainKey("company");
         createdUser.ProfileMetadata.Values["company"].ShouldBe("Acme");
 
-        var email = _factory.EmailSender.Sent.ShouldHaveSingleItem();
+        var email = _factory.EmailSender.Sent
+            .Where(item => item.ToEmail == uniqueEmail)
+            .ShouldHaveSingleItem();
         email.ToEmail.ShouldBe(uniqueEmail);
         email.TemplateKey.ShouldBe(TemplatedEmailKeys.AccountConfirmation);
         email.Variables.ShouldContainKey("confirmationUrl");
+    }
+
+    [Fact]
+    public async Task RegisterUser_UsesConfiguredFullNameAsDisplayName()
+    {
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.PostConfigure<RegistrationOptions>(options =>
+                {
+                    options.ProfileFields = new List<RegistrationProfileFieldOptions>
+                    {
+                        new()
+                        {
+                            Name = "fullName",
+                            DisplayName = "Full name",
+                            Required = true,
+                            MaxLength = 128
+                        }
+                    };
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+        var uniqueEmail = $"full-name-{Guid.NewGuid():N}@example.com";
+
+        var response = await client.PostAsJsonAsync("/auth/register", new
+        {
+            email = uniqueEmail,
+            password = "Passw0rd!Passw0rd!",
+            metadata = new { fullName = "Configured Full Name" }
+        });
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.Accepted, responseBody);
+
+        using var scope = factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var createdUser = await dbContext.Users.SingleAsync(user => user.Email == uniqueEmail);
+        createdUser.DisplayName.ShouldBe("Configured Full Name");
     }
 
     [Fact]

--- a/Identity.Base.Tests/UserEndpointsTests.cs
+++ b/Identity.Base.Tests/UserEndpointsTests.cs
@@ -8,8 +8,10 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Shouldly;
 using Identity.Base.Identity;
+using Identity.Base.Options;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Identity;
 using Xunit;
@@ -180,6 +182,34 @@ public class UserEndpointsTests : IClassFixture<IdentityApiFactory>
         using var document = JsonDocument.Parse(payload);
         document.RootElement.GetProperty("email").GetString().ShouldBe(email);
         document.RootElement.GetProperty("concurrencyStamp").GetString().ShouldNotBeNullOrWhiteSpace();
+        document.RootElement.GetProperty("createdAt").GetDateTimeOffset().ShouldNotBe(default);
+    }
+
+    [Fact]
+    public async Task GetCurrentUser_UsesConfiguredFullName_WhenStoredDisplayNameIsEmpty()
+    {
+        const string email = "users-me-existing-full-name@example.com";
+        const string password = "StrongPass!2345";
+
+        using var factory = CreateFullNameFactory();
+        await SeedUserAsync(factory, email, password, confirmEmail: true);
+        using (var scope = factory.Services.CreateScope())
+        {
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+            var user = await userManager.FindByEmailAsync(email);
+            user.ShouldNotBeNull();
+            user!.DisplayName = null;
+            user.SetProfileMetadata(new Dictionary<string, string?> { ["fullName"] = "Existing Full Name" });
+            (await userManager.UpdateAsync(user)).Succeeded.ShouldBeTrue();
+        }
+
+        using var client = await CreateAuthenticatedClientAsync(factory, email, password);
+        var response = await client.GetAsync("/users/me");
+        var payload = await response.Content.ReadAsStringAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, payload);
+
+        using var document = JsonDocument.Parse(payload);
+        document.RootElement.GetProperty("displayName").GetString().ShouldBe("Existing Full Name");
     }
 
     [Fact]
@@ -227,9 +257,44 @@ public class UserEndpointsTests : IClassFixture<IdentityApiFactory>
         document.RootElement.GetProperty("metadata").GetProperty("company").GetString().ShouldBe(updatedCompany);
     }
 
-    private async Task SeedUserAsync(string email, string password, bool confirmEmail)
+    [Fact]
+    public async Task UpdateProfile_UsesFullNameAsDisplayName()
     {
-        using var scope = _factory.Services.CreateScope();
+        const string email = "users-me-full-name@example.com";
+        const string password = "StrongPass!2345";
+        const string fullName = "Full Name User";
+
+        using var factory = CreateFullNameFactory();
+        await SeedUserAsync(factory, email, password, confirmEmail: true);
+
+        using var client = await CreateAuthenticatedClientAsync(factory, email, password);
+        var meResponse = await client.GetAsync("/users/me");
+        using var meDocument = JsonDocument.Parse(await meResponse.Content.ReadAsStringAsync());
+        var concurrencyStamp = meDocument.RootElement.GetProperty("concurrencyStamp").GetString();
+
+        var response = await client.PutAsJsonAsync("/users/me/profile", new
+        {
+            concurrencyStamp,
+            metadata = new { fullName }
+        }, JsonOptions);
+
+        var payload = await response.Content.ReadAsStringAsync();
+        response.StatusCode.ShouldBe(HttpStatusCode.OK, payload);
+        using var document = JsonDocument.Parse(payload);
+        document.RootElement.GetProperty("displayName").GetString().ShouldBe(fullName);
+        document.RootElement.GetProperty("createdAt").GetDateTimeOffset().ShouldNotBe(default);
+    }
+
+    private async Task SeedUserAsync(string email, string password, bool confirmEmail)
+        => await SeedUserAsync(_factory, email, password, confirmEmail);
+
+    private static async Task SeedUserAsync(
+        WebApplicationFactory<Program> factory,
+        string email,
+        string password,
+        bool confirmEmail)
+    {
+        using var scope = factory.Services.CreateScope();
         var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
 
         var user = await userManager.FindByEmailAsync(email);
@@ -256,8 +321,14 @@ public class UserEndpointsTests : IClassFixture<IdentityApiFactory>
     }
 
     private async Task<HttpClient> CreateAuthenticatedClientAsync(string email, string password)
+        => await CreateAuthenticatedClientAsync(_factory, email, password);
+
+    private static async Task<HttpClient> CreateAuthenticatedClientAsync(
+        WebApplicationFactory<Program> factory,
+        string email,
+        string password)
     {
-        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions
         {
             BaseAddress = new Uri("https://localhost"),
             HandleCookies = true,
@@ -276,4 +347,25 @@ public class UserEndpointsTests : IClassFixture<IdentityApiFactory>
 
         return client;
     }
+
+    private WebApplicationFactory<Program> CreateFullNameFactory()
+        => _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.PostConfigure<RegistrationOptions>(options =>
+                {
+                    options.ProfileFields = new List<RegistrationProfileFieldOptions>
+                    {
+                        new()
+                        {
+                            Name = "fullName",
+                            DisplayName = "Full name",
+                            Required = true,
+                            MaxLength = 128
+                        }
+                    };
+                });
+            });
+        });
 }

--- a/Identity.Base.Tests/UserProfileResponseTests.cs
+++ b/Identity.Base.Tests/UserProfileResponseTests.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using Identity.Base.Features.Users;
+using Shouldly;
+
+namespace Identity.Base.Tests;
+
+public class UserProfileResponseTests
+{
+    [Fact]
+    public void Serialization_IncludesCreatedAt()
+    {
+        var createdAt = new DateTimeOffset(2026, 7, 27, 12, 30, 0, TimeSpan.Zero);
+        var response = new UserProfileResponse(
+            Guid.NewGuid(),
+            "person@example.com",
+            true,
+            "Person",
+            new Dictionary<string, string?> { ["fullName"] = "Person" },
+            "stamp",
+            false,
+            createdAt);
+
+        var json = JsonSerializer.Serialize(response, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        using var document = JsonDocument.Parse(json);
+
+        document.RootElement.GetProperty("createdAt").GetDateTimeOffset().ShouldBe(createdAt);
+    }
+}

--- a/Identity.Base/Features/Authentication/Register/RegisterUserEndpoint.cs
+++ b/Identity.Base/Features/Authentication/Register/RegisterUserEndpoint.cs
@@ -110,13 +110,7 @@ public static class RegisterUserEndpoint
     }
 
     private static string? ResolveDisplayName(RegisterUserRequest request, RegistrationOptions options)
-    {
-        var preferredField = options.ProfileFields.FirstOrDefault(field => field.Name.Equals("displayName", StringComparison.OrdinalIgnoreCase));
-        if (preferredField is not null && request.Metadata.TryGetValue(preferredField.Name, out var displayName) && !string.IsNullOrWhiteSpace(displayName))
-        {
-            return displayName;
-        }
-
-        return null;
-    }
+        => IdentityDisplayNameResolver.Resolve(
+            new Dictionary<string, string?>(request.Metadata, StringComparer.OrdinalIgnoreCase),
+            options.ProfileFields);
 }

--- a/Identity.Base/Features/Users/UserEndpoints.cs
+++ b/Identity.Base/Features/Users/UserEndpoints.cs
@@ -55,6 +55,7 @@ public static class UserEndpoints
     private static async Task<IResult> GetCurrentUserAsync(
         HttpContext context,
         UserManager<ApplicationUser> userManager,
+        IOptions<RegistrationOptions> registrationOptions,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -65,14 +66,20 @@ public static class UserEndpoints
             return Results.Unauthorized();
         }
 
+        var metadata = user.ProfileMetadata.Values;
+        var displayName = !string.IsNullOrWhiteSpace(user.DisplayName)
+            ? user.DisplayName
+            : IdentityDisplayNameResolver.Resolve(metadata, registrationOptions.Value.ProfileFields);
+
         return Results.Ok(new UserProfileResponse(
             user.Id,
             user.Email,
             user.EmailConfirmed,
-            user.DisplayName,
-            user.ProfileMetadata.Values,
+            displayName,
+            metadata,
             user.ConcurrencyStamp ?? string.Empty,
-            user.TwoFactorEnabled));
+            user.TwoFactorEnabled,
+            user.CreatedAt));
     }
 
     private static async Task<IResult> UpdateProfileAsync(
@@ -130,7 +137,8 @@ public static class UserEndpoints
 
         user.SetProfileMetadata(normalized);
 
-        if (normalized.TryGetValue("displayName", out var displayName) && !string.IsNullOrWhiteSpace(displayName))
+        var displayName = IdentityDisplayNameResolver.Resolve(normalized, fields);
+        if (!string.IsNullOrWhiteSpace(displayName))
         {
             user.DisplayName = displayName.Trim();
         }
@@ -160,7 +168,8 @@ public static class UserEndpoints
             user.DisplayName,
             user.ProfileMetadata.Values,
             user.ConcurrencyStamp ?? string.Empty,
-            user.TwoFactorEnabled));
+            user.TwoFactorEnabled,
+            user.CreatedAt));
     }
 
     private static async Task<IResult> ChangePasswordAsync(
@@ -245,7 +254,8 @@ internal sealed record UserProfileResponse(
     string? DisplayName,
     IReadOnlyDictionary<string, string?> Metadata,
     string ConcurrencyStamp,
-    bool TwoFactorEnabled);
+    bool TwoFactorEnabled,
+    DateTimeOffset CreatedAt);
 
 internal sealed class UpdateProfileRequest
 {

--- a/Identity.Base/Identity/IdentityDisplayNameResolver.cs
+++ b/Identity.Base/Identity/IdentityDisplayNameResolver.cs
@@ -1,0 +1,29 @@
+using Identity.Base.Options;
+
+namespace Identity.Base.Identity;
+
+internal static class IdentityDisplayNameResolver
+{
+    private static readonly string[] PreferredFieldNames = ["displayName", "fullName"];
+
+    public static string? Resolve(
+        IReadOnlyDictionary<string, string?> metadata,
+        IEnumerable<RegistrationProfileFieldOptions> configuredFields)
+    {
+        foreach (var preferredName in PreferredFieldNames)
+        {
+            var configuredField = configuredFields.FirstOrDefault(field =>
+                field.Name.Equals(preferredName, StringComparison.OrdinalIgnoreCase));
+            if (configuredField is null ||
+                !metadata.TryGetValue(configuredField.Name, out var value) ||
+                string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            return value.Trim();
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

- return `createdAt` from the current-user profile endpoint, matching the published client contract
- promote configured `fullName` profile fields to the user display name on registration and profile updates
- resolve the configured full name for existing users whose stored display-name column is empty
- preserve `displayName` as the preferred alias when both fields are configured
- add focused resolver, serialization, and endpoint regression coverage

## Root cause

The TypeScript client declared `createdAt`, but `UserProfileResponse` omitted it. Display-name synchronization also recognized only a profile field literally named `displayName`, while maintained applications configure the user-facing name as `fullName`.

## Impact

Cobalt and Borealis account settings can display the persisted account creation date and a consistent name after consumers update to the released package.

## Validation

- `dotnet build Identity.Base/Identity.Base.csproj --configuration Release --no-restore --nologo`
- `dotnet test Identity.Base.Tests/Identity.Base.Tests.csproj --filter 'FullyQualifiedName~IdentityDisplayNameResolverTests|FullyQualifiedName~UserProfileResponseTests' -m:1 /nodeReuse:false --nologo` (3 passed)

The broader macOS integration-test run is currently blocked before assertions by an existing Apple keychain error while OpenIddict loads its development certificate. CI runs on Linux and will provide the complete integration result.
